### PR TITLE
Filepath handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ffmpeg-next = "4.3.7"
+glib = "0.10.3"
 gstreamer = "0.16.5"
-termion = "1.5.1"
 device_query = "0.1.0"
+url = "1.5.1"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,29 @@ use glib;
 pub mod stream_info;
 pub mod inputs;
 pub mod events;
-
+pub mod uri;
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    //args 0 has the reference to binaries, the first filepath will then be in point 1
+    //TODO: Encorporate more use of args to play multiple files, preferably after a --playlist tag
+
+    let path = &args[1];
     gstreamer::init().unwrap();
     let device_state = DeviceState::new();
     //TODO Implement a filepath to URI function and then this doesn't have to be hardcoded, this is just a test case.
     //TODO Use the GNU online videos for unit testing purposes.
     // TODO Implement unit tests.
-    let filepath2 = "file:///media/mep19mj/Anime%201/TV%20Shows/Psych/Psych.Season.5.720p.x265.HEVC-LION%5BUTR%5D/Psych.S05E07.720p.x265.HEVC-LION[UTR].mkv";
-    //let filepath = "file:///media/mep19mj/Anime%201/Anime/Code%20Geass%20Lelouch%20of%20the%20Rebellion/Code%20Geass%20Lelouch%20of%20the%20Rebellion%20R1%2003.mkv";
-    let filepath = "file:///media/mep19mj/Anime%201/Anime/Flip%20Flappers/%20Flip%20Flappers%20-%2001.mkv";
+
+    //For use in unit tests.
+    //let test_path = ""https://www.freedesktop.org/software/gstreamer-sdk/data/media/sintel_cropped_multilingual.webm";
+
+    let filepath = uri::get_uri_from_path(path);
+
     let pipe = format!("playbin uri={} name=play video-sink='autovideosink' audio-sink='autoaudiosink'", filepath);
+
+
+
     let mut pipeline = gstreamer::parse_launch(&pipe).unwrap();
 
     pipeline.set_state(gstreamer::State::Playing).expect("Unable to set to playing");

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,0 +1,11 @@
+use std::path;
+use url::Url;
+
+pub fn get_uri_from_path(filepath: &str) -> String {
+    let path = std::path::Path::new(filepath);
+    let uri = url::Url::from_file_path(path).unwrap();
+    println!("{}",uri.as_str().to_string());
+    return uri.as_str().to_string();
+
+
+}


### PR DESCRIPTION
- Added some naive filepath handling, now Iggy-Player can be called on a filepath as a command line argument and run providing gstreamer supports the file.